### PR TITLE
Corrigir texto das licenças

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer>
 <div class="container">
   <div class="esquerda">
-  <h6>Este projeto é publicado sobre as regras do Creative Commons, com livre distribuição,
+  <h6>Este projeto é publicado sob as regras do Creative Commons, com livre distribuição,
     inclusive para uso comercial, desde que haja crédito ao Volt Data Lab e que seu projeto
     tenha a mesma licença.</h6>
     <h6>Para mais informações, <a href="LICENSE.html">clique aqui</a>.</h6>


### PR DESCRIPTION
Licenciado `sob` CC, não `sobre`.
Análogo a "trabalha _sob_ as normas da delegacia".
Vide https://www.dicio.com.br/sob/